### PR TITLE
fix: add uri for platforms selector

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,11 @@ jobs:
           fi
       - name: Install plugin from repository
         run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           trivy plugin install github.com/dramf/md?ref=${{ github.event.pull_request.head.sha }}
+          else 
+          trivy plugin install github.com/dramf/md?ref=${{ github.sha }}
+          fi
           trivy plugin info md
           rm -rf ~/.trivy/plugins/md
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Go mod tidy
         run: |
@@ -39,7 +37,7 @@ jobs:
           fi
       - name: Install plugin from repository
         run: |
-          trivy plugin install github.com/dramf/md?ref=${{ github.sha }}
+          trivy plugin install github.com/dramf/md?ref=${{ github.event.pull_request.head.sha }}
           trivy plugin info md
           rm -rf ~/.trivy/plugins/md
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Go mod tidy
         run: |
@@ -37,7 +39,7 @@ jobs:
           fi
       - name: Install plugin from repository
         run: |
-          trivy plugin install github.com/dramf/md?ref=$GITHUB_HEAD_SHA
+          trivy plugin install github.com/dramf/md?ref=${{ github.sha }}
           trivy plugin info md
           rm -rf ~/.trivy/plugins/md
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,5 @@
 name: Test
 on:
-  push:
   pull_request:
     branches:
       - main
@@ -37,11 +36,7 @@ jobs:
           fi
       - name: Install plugin from repository
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           trivy plugin install github.com/dramf/md?ref=${{ github.event.pull_request.head.sha }}
-          else 
-          trivy plugin install github.com/dramf/md?ref=${{ github.sha }}
-          fi
           trivy plugin info md
           rm -rf ~/.trivy/plugins/md
 
@@ -49,8 +44,7 @@ jobs:
         run: |
           go build ./
           mkdir -p ~/.trivy/plugins/md
-          mv md ~/.trivy/plugins/md/
-          cp plugin.yaml ~/.trivy/plugins/md/
+          cp md plugin.yaml ~/.trivy/plugins/md/
           trivy plugin info md
           rm -rf ~/.trivy/plugins/md
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           fi
       - name: Install plugin from repository
         run: |
-          trivy plugin install github.com/dramf/md?ref=${{github.sha}}
+          trivy plugin install github.com/dramf/md?ref=$GITHUB_SHA
           trivy plugin info md
           rm -rf ~/.trivy/plugins/md
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04, macos-12 ]
-        plugin-release:
-          - os: ubuntu-22.04
-            url: https://github.com/dramf/md/releases/download/v0.1.0/md_0.1.0_linux-amd64.tar.gz
-          - os: macos-12
-            url: https://github.com/dramf/md/releases/download/v0.1.0/md_0.1.0_darwin-arm64.tar.gz
+
     name: Test
     runs-on: ${{ matrix.os }}
     steps:
@@ -41,18 +37,7 @@ jobs:
           fi
       - name: Install plugin from repository
         run: |
-          trivy plugin install github.com/dramf/md
-          trivy plugin info md
-          rm -rf ~/.trivy/plugins/md
-
-      - name: Install plugin from release
-        run: |
-          PLUGIN_URL=${{ matrix.plugin-release.url }}
-          curl -L $PLUGIN_URL -o md-plugin.tar.gz
-          tar -xzf md-plugin.tar.gz
-          mkdir -p ~/.trivy/plugins/md
-          mv md ~/.trivy/plugins/md/
-          cp plugin.yaml ~/.trivy/plugins/md/
+          trivy plugin install github.com/dramf/md?ref=${{github.sha}}
           trivy plugin info md
           rm -rf ~/.trivy/plugins/md
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           fi
       - name: Install plugin from repository
         run: |
-          trivy plugin install github.com/dramf/md?ref=$GITHUB_SHA
+          trivy plugin install github.com/dramf/md?ref=$GITHUB_HEAD_SHA
           trivy plugin info md
           rm -rf ~/.trivy/plugins/md
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,14 +9,25 @@ env:
 
 jobs:
   unittest:
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04, macos-12 ]
+        plugin-release:
+          - os: ubuntu-22.04
+            url: https://github.com/dramf/md/releases/download/v0.1.0/md_0.1.0_linux-amd64.tar.gz
+          - os: macos-12
+            url: https://github.com/dramf/md/releases/download/v0.1.0/md_0.1.0_darwin-arm64.tar.gz
     name: Test
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     steps:
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@v0.2.2
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -28,6 +39,31 @@ jobs:
             echo "Run 'go mod tidy' and push it"
             exit 1
           fi
+      - name: Install plugin from repository
+        run: |
+          trivy plugin install github.com/dramf/md
+          trivy plugin info md
+          rm -rf ~/.trivy/plugins/md
+
+      - name: Install plugin from release
+        run: |
+          PLUGIN_URL=${{ matrix.plugin-release.url }}
+          curl -L $PLUGIN_URL -o md-plugin.tar.gz
+          tar -xzf md-plugin.tar.gz
+          mkdir -p ~/.trivy/plugins/md
+          mv md ~/.trivy/plugins/md/
+          cp plugin.yaml ~/.trivy/plugins/md/
+          trivy plugin info md
+          rm -rf ~/.trivy/plugins/md
+
+      - name: Install plugin from local file
+        run: |
+          go build ./
+          mkdir -p ~/.trivy/plugins/md
+          mv md ~/.trivy/plugins/md/
+          cp plugin.yaml ~/.trivy/plugins/md/
+          trivy plugin info md
+          rm -rf ~/.trivy/plugins/md
 
       - name: Run unit tests
         run: go test -v -short -timeout 30s -coverprofile=coverage.txt -covermode=atomic ./...

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -8,16 +8,20 @@ platforms:
   - selector:
       os: linux
       arch: amd64
+    uri: https://github.com/dramf/md/releases/download/v0.1.0/md_0.1.0_linux-amd64.tar.gz
     bin: ./md
   - selector:
       os: linux
       arch: arm64
+    uri: https://github.com/dramf/md/releases/download/v0.1.0/md_0.1.0_linux-arm64.tar.gz
     bin: ./md
   - selector:
       os: darwin
       arch: amd64
+    uri: https://github.com/dramf/md/releases/download/v0.1.0/md_0.1.0_darwin-amd64.tar.gz
     bin: ./md
   - selector:
       os: darwin
       arch: arm64
+    uri: https://github.com/dramf/md/releases/download/v0.1.0/md_0.1.0_darwin-arm64.tar.gz
     bin: ./md


### PR DESCRIPTION
resolve error that occurs via installation from repository `trivy plugin install https://github.com/dramf/md`
test run:
- ubuntu https://github.com/olsova/md/actions/runs/11855690226/job/33040425944
- macos https://github.com/olsova/md/actions/runs/11855690226/job/33040426525